### PR TITLE
#7 データベースで持つ時刻は Utc となるように修正した

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ use std::path::PathBuf;
 mod media;
 mod server;
 
-const DEFAULT_DATA_DIR: &'static str = "./data";
-const DEFAULT_SERVER_PORT: &'static str = "9999";
+const DEFAULT_DATA_DIR: &str = "./data";
+const DEFAULT_SERVER_PORT: &str = "9999";
 
 #[derive(Parser, Debug)]
 #[clap(about, version, author)]
@@ -75,7 +75,7 @@ async fn main() -> Result<()> {
                 }
                 if let Ok(origin) = origin.canonicalize() {
                     log::info!("start origin ({:#?})", origin);
-                    match Media::generate(&origin, &dest, &option).await {
+                    match Media::generate(&origin, dest, option).await {
                         Ok(media) => log::info!("{:#?}: OK", media.meta.origin),
                         Err(e) => log::info!("{:#?}: {:?}", origin, e),
                     }
@@ -103,8 +103,8 @@ async fn main() -> Result<()> {
 
                 loop {
                     match rx.recv() {
-                        Ok(Write(origin)) => from_event_path(origin, &dest, &option).await,
-                        Ok(Create(origin)) => from_event_path(origin, &dest, &option).await,
+                        Ok(Write(origin)) => from_event_path(origin, dest, &option).await,
+                        Ok(Create(origin)) => from_event_path(origin, dest, &option).await,
                         Ok(_event) => {}
                         Err(e) => log::debug!("watch error: {:?}", e),
                     }
@@ -112,14 +112,14 @@ async fn main() -> Result<()> {
             }
 
             if origin.is_dir() {
-                let medias = Media::generate_many(&origin, &dest, &option).await?;
+                let medias = Media::generate_many(origin, dest, &option).await?;
 
                 log::debug!("{:#?}", medias);
 
                 return Ok(());
             }
 
-            let media = Media::generate(&origin, &dest, &option).await?;
+            let media = Media::generate(origin, dest, &option).await?;
 
             log::debug!("{:#?}", media);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ async fn fix_date(data_dir: &str) -> Result<()> {
     .await?;
 
     for MediaIdWithDateRow { media_id, date } in medias {
-        let local_date = Local.from_utc_datetime(&date).naive_local();
+        let local_date = Local.from_utc_datetime(&date).naive_utc();
         const QUERY: &str = r#"
             update metas
             set date = ?

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,14 +37,14 @@ struct GenerateMediaSubcommand {
 #[clap(about, version, author)]
 enum App {
     #[clap(name = "start-server")]
-    StartServerSubcommand(StartServerSubcommand),
+    StartServer(StartServerSubcommand),
 
     #[clap(name = "generate-media")]
-    GenerateMediaSubcommand(GenerateMediaSubcommand),
+    GenerateMedia(GenerateMediaSubcommand),
 
     /// データベースに記録した時刻を Local に直す
     #[clap(name = "fix-date")]
-    FixDateSubcommand { database_path: String },
+    FixDate { database_path: String },
 }
 
 #[tokio::main]
@@ -55,7 +55,7 @@ async fn main() -> Result<()> {
     env_logger::init();
 
     match args {
-        App::StartServerSubcommand(s) => {
+        App::StartServer(s) => {
             use server::*;
             use std::path::Path;
 
@@ -68,7 +68,7 @@ async fn main() -> Result<()> {
 
             Ok(())
         }
-        App::GenerateMediaSubcommand(s) => {
+        App::GenerateMedia(s) => {
             use media::*;
             use std::path::Path;
 
@@ -129,7 +129,7 @@ async fn main() -> Result<()> {
 
             Ok(())
         }
-        App::FixDateSubcommand { database_path } => fix_date(&database_path).await,
+        App::FixDate { database_path } => fix_date(&database_path).await,
     }
 }
 

--- a/src/media/common.rs
+++ b/src/media/common.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 const TARGET_EXTENSIONS: [&str; 2] = ["jpeg", "jpg"];
 
 // メディアのディレクトリ
-pub const MEDIA_DIRECTORY_NAME: &'static str = "media";
+pub const MEDIA_DIRECTORY_NAME: &str = "media";
 
 /// path のファイルを再起的に全て取得する
 pub fn get_filenames_recursive(path: &Path, depth: u32) -> Vec<PathBuf> {
@@ -27,7 +27,7 @@ pub fn get_filenames_recursive(path: &Path, depth: u32) -> Vec<PathBuf> {
             if path.is_dir() {
                 get_filenames_recursive(&path, depth - 1)
             } else {
-                vec![path.to_owned()]
+                vec![path]
             }
         })
         .collect()
@@ -51,7 +51,9 @@ pub fn get_image_filenames(dir: &Path) -> Vec<PathBuf> {
 
     let entries = get_filenames_recursive(dir, RECURSIVE_DEPTH);
 
-    let entries = entries
+    
+
+    entries
         .into_iter()
         .flat_map(|path| {
             if is_target(&path) {
@@ -60,7 +62,5 @@ pub fn get_image_filenames(dir: &Path) -> Vec<PathBuf> {
                 None
             }
         })
-        .collect::<Vec<_>>();
-
-    entries
+        .collect::<Vec<_>>()
 }

--- a/src/media/media.rs
+++ b/src/media/media.rs
@@ -154,7 +154,7 @@ impl Media {
 
 /// EXIF から 日付を取得する
 async fn get_exif_date(path: &Path) -> Result<chrono::NaiveDateTime> {
-    use chrono::NaiveDateTime;
+    use chrono::{Local, TimeZone};
     use exif::{In, Reader, Tag};
     use std::fs::File; // ここtoio化したい
     use std::io::BufReader;
@@ -171,7 +171,8 @@ async fn get_exif_date(path: &Path) -> Result<chrono::NaiveDateTime> {
     };
 
     // できればミリ秒までの精度が欲しいけどなあ
-    let date = NaiveDateTime::parse_from_str(field.as_str(), "%Y-%m-%d %H:%M:%S")?;
+    let date = Local.datetime_from_str(field.as_str(), "%Y-%m-%d %H:%M:%S")?;
+    let date = date.naive_local();
 
     Ok(date)
 }

--- a/src/media/media.rs
+++ b/src/media/media.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use tokio::task;
 
 // サムネイルの画像ファイル名
-const THUMB_FILE_NAME: &'static str = "thumb.jpg";
+const THUMB_FILE_NAME: &str = "thumb.jpg";
 
 // SQLite3データベースを返す
 pub async fn create_connection(data_directory: &Path) -> Result<SqliteConnection> {
@@ -29,13 +29,8 @@ impl From<MediaMeta> for Media {
     }
 }
 
+#[derive(Default)]
 pub struct MediaGenerateOption {}
-
-impl Default for MediaGenerateOption {
-    fn default() -> Self {
-        MediaGenerateOption {}
-    }
-}
 
 impl Media {
     /// ファイルを指定して生成する
@@ -50,7 +45,7 @@ impl Media {
         let mut conn = create_connection(data_directory).await?;
 
         // ファイルのハッシュ値を取得する
-        let hashed = get_file_hash(&origin).await?;
+        let hashed = get_file_hash(origin).await?;
 
         // ハッシュ値が一致している場合は生成しない
         if let Ok(meta) = MediaMeta::get_by_hashed(&mut conn, &hashed).await {
@@ -60,9 +55,9 @@ impl Media {
 
         // 日付を取得する
         // exif -> file created at -> now とフォールバックしたい
-        let date = if let Ok(date) = get_exif_date(&origin).await {
+        let date = if let Ok(date) = get_exif_date(origin).await {
             date
-        } else if let Ok(date) = get_file_created_date(&origin).await {
+        } else if let Ok(date) = get_file_created_date(origin).await {
             date
         } else {
             Utc::now().naive_utc()
@@ -102,7 +97,7 @@ impl Media {
 
         let entries = entries
             .iter()
-            .map(|entry| Media::generate(&entry, data_directory, option));
+            .map(|entry| Media::generate(entry, data_directory, option));
         let mut medias = Vec::<Media>::with_capacity(entries.len());
         let mut stream = stream::iter(entries);
 

--- a/src/media/media.rs
+++ b/src/media/media.rs
@@ -1,9 +1,7 @@
-use super::common::*;
-use super::meta::*;
+use super::{common::*, meta::*};
 use anyhow::Result;
-use chrono::Utc;
-use sqlx::Connection;
-use sqlx::SqliteConnection;
+use chrono::prelude::*;
+use sqlx::{Connection, SqliteConnection};
 use std::path::Path;
 use tokio::task;
 
@@ -154,7 +152,6 @@ impl Media {
 
 /// EXIF から 日付を取得する
 async fn get_exif_date(path: &Path) -> Result<chrono::NaiveDateTime> {
-    use chrono::{Local, TimeZone};
     use exif::{In, Reader, Tag};
     use std::fs::File; // ここtoio化したい
     use std::io::BufReader;
@@ -179,7 +176,6 @@ async fn get_exif_date(path: &Path) -> Result<chrono::NaiveDateTime> {
 
 /// ファイルのメタデータから日付を取得する
 async fn get_file_created_date(path: &Path) -> Result<chrono::NaiveDateTime> {
-    use chrono::{Local, NaiveDateTime, TimeZone};
     use std::time::UNIX_EPOCH;
     use tokio::fs::File;
 

--- a/src/media/media.rs
+++ b/src/media/media.rs
@@ -164,7 +164,7 @@ async fn get_exif_date(path: &Path) -> Result<chrono::NaiveDateTime> {
 
     // できればミリ秒までの精度が欲しいけどなあ
     let date = Local.datetime_from_str(field.as_str(), "%Y-%m-%d %H:%M:%S")?;
-    let date = date.naive_local();
+    let date = date.naive_utc();
 
     Ok(date)
 }
@@ -186,7 +186,7 @@ async fn get_file_created_date(path: &Path) -> Result<chrono::NaiveDateTime> {
         Some(created) => created,
         _ => bail!("Err create NaiveDateTime"),
     };
-    let created = Local.from_utc_datetime(&created).naive_local();
+    let created = Local.from_utc_datetime(&created).naive_utc();
 
     Ok(created)
 }

--- a/src/media/media.rs
+++ b/src/media/media.rs
@@ -179,7 +179,7 @@ async fn get_exif_date(path: &Path) -> Result<chrono::NaiveDateTime> {
 
 /// ファイルのメタデータから日付を取得する
 async fn get_file_created_date(path: &Path) -> Result<chrono::NaiveDateTime> {
-    use chrono::NaiveDateTime;
+    use chrono::{Local, NaiveDateTime, TimeZone};
     use std::time::UNIX_EPOCH;
     use tokio::fs::File;
 
@@ -190,11 +190,12 @@ async fn get_file_created_date(path: &Path) -> Result<chrono::NaiveDateTime> {
     let created = created.duration_since(UNIX_EPOCH)?;
     let created = match NaiveDateTime::from_timestamp_opt(
         created.as_secs() as i64,
-        created.as_nanos() as u32,
+        created.subsec_nanos() as u32,
     ) {
         Some(created) => created,
         _ => bail!("Err create NaiveDateTime"),
     };
+    let created = Local.from_utc_datetime(&created).naive_local();
 
     Ok(created)
 }

--- a/src/media/meta.rs
+++ b/src/media/meta.rs
@@ -112,7 +112,7 @@ impl MediaId {
         .fetch_all(conn)
         .await?;
         let last = ids.last().map(|row| row.date).unwrap_or(end);
-        let ids: Vec<MediaId> = ids.into_iter().map(|row| row.media_id.into()).collect();
+        let ids: Vec<MediaId> = ids.into_iter().map(|row| row.media_id).collect();
 
         Ok((ids, last))
     }
@@ -184,7 +184,7 @@ impl MediaMeta {
         Ok(())
     }
 
-    pub async fn open(conn: &mut SqliteConnection, media_id: &String) -> Result<Self> {
+    pub async fn open(conn: &mut SqliteConnection, media_id: &str) -> Result<Self> {
         let meta = query_as("select * from metas where media_id = $1")
             .bind(media_id.to_string())
             .fetch_one(conn)
@@ -192,7 +192,7 @@ impl MediaMeta {
         Ok(meta)
     }
 
-    pub async fn get_by_hashed(conn: &mut SqliteConnection, hashed: &Vec<u8>) -> Result<Self> {
+    pub async fn get_by_hashed(conn: &mut SqliteConnection, hashed: &[u8]) -> Result<Self> {
         let meta = query_as("select * from metas where hashed = $1")
             .bind(hashed)
             .fetch_one(conn)

--- a/src/server/handler/media.rs
+++ b/src/server/handler/media.rs
@@ -60,7 +60,7 @@ pub async fn get_media_ids(req: HttpRequest) -> HttpResponse {
         }
         Err(err) => {
             log::debug!("{:?}", err);
-            return HttpResponse::InternalServerError().body("");
+            HttpResponse::InternalServerError().body("")
         }
     }
 }


### PR DESCRIPTION
close #7 

- EXIF やファイルのメタから取得した時刻はローカルのものと見做して、Utc に変換してからデータベースに放り込むように修正した
- `fix-date` を叩けば時刻を Utc に直す <- 誤爆こえ～
